### PR TITLE
Fix Report View

### DIFF
--- a/sonar-dependency-check-plugin/src/main/resources/static/report.js
+++ b/sonar-dependency-check-plugin/src/main/resources/static/report.js
@@ -31,7 +31,7 @@ window.registerExtension("dependencycheck/report", function(options) {
 	}
 	
 	window.SonarRequest.getJSON("/api/measures/component", {
-		componentKey : options.component.key,
+		component : options.component.key,
 		metricKeys : "report"
 	}).then(function(response) {
 		if (isDisplayed) {


### PR DESCRIPTION
Noticed that the use of `componentKey` is deprecated since sonarqube 6.6. I think it's time to switch to `component`.
Fix #194