### PR TITLE
Deprecate XML-Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependency-Check supports the identification of project dependencies in a number
 
 ## Note
 
-**This SonarQube plugin does not perform analysis**, rather, it reads existing Dependency-Check reports. Use one of the other available methods to scan project dependencies and generate the necessary JSON or XML report which can then be consumed by this plugin. Refer to the [Dependency-Check project](https://github.com/jeremylong/DependencyCheck) for relevant [documentation](https://jeremylong.github.io/DependencyCheck/).
+**This SonarQube plugin does not perform analysis**, rather, it reads existing Dependency-Check reports. Use one of the other available methods to scan project dependencies and generate the necessary JSON report which can then be consumed by this plugin. Refer to the [Dependency-Check project](https://github.com/jeremylong/DependencyCheck) for relevant [documentation](https://jeremylong.github.io/DependencyCheck/).
 
 ## Metrics
 
@@ -76,19 +76,18 @@ Copy the plugin (jar file) to $SONAR_INSTALL_DIR/extensions/plugins and restart 
 
 ## Using
 
-Create aggregate reports with Dependency-Check. Dependency-Check will output a file named 'dependency-check-report.json' or 'dependency-check-report.xml'. The Dependency-Check SonarQube plugin reads an existing Dependency-Check JSON or XML report.
+Create aggregate reports with Dependency-Check. Dependency-Check will output a file named 'dependency-check-report.json'. The Dependency-Check SonarQube plugin reads an existing Dependency-Check JSON report.
 
 ## Plugin Configuration
 
 A typical SonarQube configuration will have the following parameter. This example assumes the use of a Jenkins workspace, but can easily be altered for other CI/CD systems.
 
 ```ini
-sonar.dependencyCheck.xmlReportPath=${WORKSPACE}/dependency-check-report.xml
 sonar.dependencyCheck.jsonReportPath=${WORKSPACE}/dependency-check-report.json
 sonar.dependencyCheck.htmlReportPath=${WORKSPACE}/dependency-check-report.html
 ```
 
-In this example, all supported reports (JSON, XML and HTML) are specified. This plugin prefers the JSON over the XML report. At the moment the XML report isn't deprecated, but that might be an option in future. Only the JSON/XML report is required, however, if the HTML report is also available, it greatly enhances the usability of the SonarQube plugin by incorporating the actual Dependency-Check HTML report in the SonarQube project.
+In this example, all supported reports (JSON and HTML) are specified. Only the JSON report is required, however, if the HTML report is also available, it greatly enhances the usability of the SonarQube plugin by incorporating the actual Dependency-Check HTML report in the SonarQube project.
 
 This plugin tries to add SonarQube issues to your project configuration files (e.g. pom.xml, \*.gradle, package-json.lock). Please make sure, that these files are part of `sonar.sources`.
 

--- a/examples/single-module-gradle/build.gradle
+++ b/examples/single-module-gradle/build.gradle
@@ -34,7 +34,7 @@ dependencyCheck {
 
 sonarqube {
     properties {
-        property 'sonar.dependencyCheck.xmlReportPath', 'build/reports/dependency-check-report.xml'
+        property 'sonar.dependencyCheck.jsonReportPath', 'build/reports/dependency-check-report.json'
         property 'sonar.dependencyCheck.htmlReportPath', 'build/reports/dependency-check-report.html'
         properties["sonar.sources"] += "build.gradle"
     }

--- a/examples/single-module-kotlin-dsl-gradle/build.gradle.kts
+++ b/examples/single-module-kotlin-dsl-gradle/build.gradle.kts
@@ -31,7 +31,7 @@ dependencyCheck {
 
 sonarqube {
     properties {
-        property("sonar.dependencyCheck.xmlReportPath", "build/reports/dependency-check-report.xml")
+        property("sonar.dependencyCheck.jsonReportPath", "build/reports/dependency-check-report.json")
         property("sonar.dependencyCheck.htmlReportPath", "build/reports/dependency-check-report.html")
         property("sonar.sources", "src,build.gradle.kts")
     }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
@@ -82,6 +82,10 @@ public class DependencyCheckSensor implements ProjectSensor {
         XmlReportFile report;
         try {
             report = XmlReportFile.getXmlReport(context.config(), fileSystem, pathResolver);
+            LOGGER.warn("The XML report is deprecated and will be removed, please switch to the JSON report.");
+            if (analysisWarnings != null ) {
+                analysisWarnings.addUnique("The XML report is deprecated and will be removed, please switch to the JSON report.");
+            }
             return Optional.of(XMLReportParserHelper.parse(report.getInputStream()));
         } catch (FileNotFoundException e) {
             LOGGER.info("XML-Analysis skipped/aborted due to missing report file");

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
@@ -21,7 +21,16 @@ package org.sonar.dependencycheck.base;
 
 public final class DependencyCheckConstants {
 
+    /**
+     * @deprecated Please use the JSON Report
+     */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public static final String XML_REPORT_PATH_PROPERTY = "sonar.dependencyCheck.xmlReportPath";
+
+    /**
+     * @deprecated Please use the JSON Report
+     */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public static final String DEPRECTED_XML_REPORT_PATH_PROPERTY = "sonar.dependencyCheck.reportPath";
     public static final String JSON_REPORT_PATH_PROPERTY = "sonar.dependencyCheck.jsonReportPath";
     public static final String HTML_REPORT_PATH_PROPERTY = "sonar.dependencyCheck.htmlReportPath";
@@ -37,6 +46,11 @@ public final class DependencyCheckConstants {
     public static final Float SEVERITY_CRITICAL_DEFAULT = 7.0f;
     public static final Float SEVERITY_MAJOR_DEFAULT = 4.0f;
     public static final Float SEVERITY_MINOR_DEFAULT = 0.0f;
+
+    /**
+     * @deprecated Please use the JSON Report
+     */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public static final String XML_REPORT_PATH_DEFAULT = "${WORKSPACE}/dependency-check-report.xml";
     public static final String JSON_REPORT_PATH_DEFAULT = "${WORKSPACE}/dependency-check-report.json";
     public static final String HTML_REPORT_PATH_DEFAULT = "${WORKSPACE}/dependency-check-report.html";

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/XMLReportParserHelper.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/XMLReportParserHelper.java
@@ -29,6 +29,10 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
+/**
+ * @deprecated Please use the JSON Report
+ */
+@Deprecated(since = "3.0.0", forRemoval = true)
 public class XMLReportParserHelper {
 
     private XMLReportParserHelper() {

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/report/ReportFormat.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/report/ReportFormat.java
@@ -20,5 +20,8 @@
 package org.sonar.dependencycheck.report;
 
 public enum ReportFormat {
-    XML, HTML, JSON
+    @Deprecated(since = "3.0.0", forRemoval = true)
+    XML,
+    HTML,
+    JSON
 }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/report/XmlReportFile.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/report/XmlReportFile.java
@@ -27,6 +27,10 @@ import org.sonar.api.config.Configuration;
 import org.sonar.api.scan.filesystem.PathResolver;
 import org.sonar.dependencycheck.base.DependencyCheckConstants;
 
+/**
+ * @deprecated Please use the JsonReportFile
+ */
+@Deprecated(since = "3.0.0", forRemoval = true)
 public class XmlReportFile extends ReportFile {
 
     public static XmlReportFile getXmlReport(Configuration config, FileSystem fileSystem, PathResolver pathResolver) throws FileNotFoundException {

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/DependencyCheckSensorTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/DependencyCheckSensorTest.java
@@ -55,8 +55,9 @@ class DependencyCheckSensorTest {
     private DependencyCheckSensor sensor;
 
     private File sampleXmlReport;
+    private File sampleJsonReport;
     private File sampleHtmlReport;
-    private File sampleXMLExceptionReport;
+    private File sampleJsonExceptionReport;
 
     @BeforeEach
     public void init() throws URISyntaxException {
@@ -68,12 +69,18 @@ class DependencyCheckSensorTest {
         final URL sampleXmlResourceURI = getClass().getClassLoader().getResource("reportMultiModuleMavenExample/dependency-check-report.xml");
         assertNotNull(sampleXmlResourceURI);
         this.sampleXmlReport = Paths.get(sampleXmlResourceURI.toURI()).toFile();
+
+        final URL sampleJsonResourceURI = getClass().getClassLoader().getResource("reportMultiModuleMavenExample/dependency-check-report.json");
+        assertNotNull(sampleJsonResourceURI);
+        this.sampleJsonReport = Paths.get(sampleJsonResourceURI.toURI()).toFile();
+
         final URL sampleHtmlResourceURI = getClass().getClassLoader().getResource("reportMultiModuleMavenExample/dependency-check-report.html");
         assertNotNull(sampleHtmlResourceURI);
         this.sampleHtmlReport = Paths.get(sampleHtmlResourceURI.toURI()).toFile();
-        final URL sampleExceptionResourceURI = getClass().getClassLoader().getResource("reportWithExceptions/dependency-check-report.xml");
+
+        final URL sampleExceptionResourceURI = getClass().getClassLoader().getResource("reportWithExceptions/dependency-check-report.json");
         assertNotNull(sampleExceptionResourceURI);
-        this.sampleXMLExceptionReport = Paths.get(sampleExceptionResourceURI.toURI()).toFile();
+        this.sampleJsonExceptionReport = Paths.get(sampleExceptionResourceURI.toURI()).toFile();
     }
 
     @Test
@@ -88,43 +95,43 @@ class DependencyCheckSensorTest {
         verify(descriptor).name("Dependency-Check");
     }
     @Test
-    void shouldAnalyse() throws URISyntaxException {
+    void shouldAnalyse() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXmlReport);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(sampleJsonReport);
         sensor.execute(context);
         assertEquals(45, context.allIssues().size());
     }
 
     @Test
-    void shouldSkipIfReportWasNotFound() throws URISyntaxException {
+    void shouldSkipIfReportWasNotFound() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(null);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(null);
         sensor.execute(context);
         assertEquals(0, context.allIssues().size());
     }
 
     @Test
-    void shouldAddAnIssueForAVulnerability() throws URISyntaxException {
+    void shouldAddAnIssueForAVulnerability() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXmlReport);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(sampleJsonReport);
         sensor.execute(context);
         assertEquals(45, context.allIssues().size());
         for (Issue issue : context.allIssues()) {
@@ -133,40 +140,40 @@ class DependencyCheckSensorTest {
     }
 
     @Test
-    void shouldPersistTotalMetrics() throws URISyntaxException {
+    void shouldPersistTotalMetrics() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXmlReport);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(sampleJsonReport);
         sensor.execute(context);
         assertEquals(9, context.measures("projectKey").size());
 
     }
 
     @Test
-    void shouldPersistMetricsOnReport() throws URISyntaxException {
+    void shouldPersistMetricsOnReport() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXmlReport);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(sampleJsonReport);
         sensor.execute(context);
         assertNotNull(context.measures("projectKey"));
     }
 
     @Test
-    void shouldPersistHtmlReport() throws URISyntaxException {
+    void shouldPersistHtmlReport() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
@@ -177,37 +184,60 @@ class DependencyCheckSensorTest {
     }
 
     @Test
-    void shouldPersistSummarizeIssues() throws URISyntaxException {
+    void shouldPersistSummarizeIssues() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
         settings.setProperty(DependencyCheckConstants.SUMMARIZE_PROPERTY, Boolean.TRUE);
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXmlReport);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(sampleJsonReport);
         sensor.execute(context);
         assertEquals(7, context.allIssues().size());
     }
 
     @Test
-    void shouldSkipPlugin() throws URISyntaxException {
+    void shouldSkipPlugin() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
         settings.setProperty(DependencyCheckConstants.SKIP_PROPERTY, Boolean.TRUE);
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXmlReport);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(sampleJsonReport);
         sensor.execute(context);
         assertEquals(0, context.allIssues().size());
     }
 
     @Test
-    void shouldAddWarningsPlugin() throws URISyntaxException {
+    void shouldAddWarningsPlugin() {
+        final SensorContextTester context = SensorContextTester.create(new File(""));
+        // Plugin Configuration
+        MapSettings settings = new MapSettings();
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.json");
+        Configuration config = settings.asConfig();
+        context.setSettings(settings);
+
+        // Sensor with analysisWarnings
+        FileSystem fileSystem = mock(FileSystem.class, RETURNS_DEEP_STUBS);
+        List<String> analysisWarnings = new ArrayList<>();
+        sensor = new DependencyCheckSensor(fileSystem, this.pathResolver, analysisWarnings::add);
+
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT)))).thenReturn(sampleJsonExceptionReport);
+        sensor.execute(context);
+        assertTrue(StringUtils.contains(analysisWarnings.get(0), "Dependency-Check - "));
+        assertTrue(StringUtils.contains(analysisWarnings.get(1),"Dependency-Check - "));
+        assertFalse(StringUtils.equals(analysisWarnings.get(0), analysisWarnings.get(1)));
+        assertEquals(2, analysisWarnings.size());
+    }
+
+    @Test
+    @Deprecated(since = "3.0.0", forRemoval = true)
+    void shouldAddWarningsWithXMLReportPlugin() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
@@ -220,29 +250,27 @@ class DependencyCheckSensorTest {
         List<String> analysisWarnings = new ArrayList<>();
         sensor = new DependencyCheckSensor(fileSystem, this.pathResolver, analysisWarnings::add);
 
-        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXMLExceptionReport);
+        when(pathResolver.relativeFile(Mockito.any(File.class), Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY).orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT)))).thenReturn(sampleXmlReport);
         sensor.execute(context);
-        assertTrue(StringUtils.contains(analysisWarnings.get(0), "Dependency-Check - "));
-        assertTrue(StringUtils.contains(analysisWarnings.get(1),"Dependency-Check - "));
-        assertFalse(StringUtils.equals(analysisWarnings.get(0), analysisWarnings.get(1)));
-        assertEquals(2, analysisWarnings.size());
+        assertTrue(StringUtils.contains(analysisWarnings.get(0), "The XML report is deprecated"));
+        assertEquals(1, analysisWarnings.size());
     }
 
     @Test
-    void shouldAddSecurityHotspots() throws URISyntaxException {
+    void shouldAddSecurityHotspots() {
         final SensorContextTester context = SensorContextTester.create(new File(""));
         // Plugin Configuration
         MapSettings settings = new MapSettings();
-        settings.setProperty(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
+        settings.setProperty(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY, "dependency-check-report.xml");
         settings.setProperty(DependencyCheckConstants.SECURITY_HOTSPOT, Boolean.TRUE);
         Configuration config = settings.asConfig();
         context.setSettings(settings);
 
         when(pathResolver
                 .relativeFile(Mockito.any(File.class),
-                        Mockito.eq(config.get(DependencyCheckConstants.XML_REPORT_PATH_PROPERTY)
-                                .orElse(DependencyCheckConstants.XML_REPORT_PATH_DEFAULT))))
-                                        .thenReturn(sampleXmlReport);
+                        Mockito.eq(config.get(DependencyCheckConstants.JSON_REPORT_PATH_PROPERTY)
+                                .orElse(DependencyCheckConstants.JSON_REPORT_PATH_DEFAULT))))
+                                        .thenReturn(sampleJsonReport);
         sensor.execute(context);
         assertEquals(45, context.allIssues().size());
         for (Issue issue : context.allIssues()) {

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/base/DependencyCheckUtilsTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/base/DependencyCheckUtilsTest.java
@@ -221,9 +221,9 @@ class DependencyCheckUtilsTest {
     @Test
     void testBestDependencyReasonJavaDependency() {
         Path path = new File("root").toPath();
-        InputFile packagLock = new TestInputFileBuilder("moduleKey", "package-lock.json").setContents("123456").setCharset(StandardCharsets.UTF_8).setModuleBaseDir(path).build();
+        InputFile packageLock = new TestInputFileBuilder("moduleKey", "package-lock.json").setContents("123456").setCharset(StandardCharsets.UTF_8).setModuleBaseDir(path).build();
         InputFile subpom = new TestInputFileBuilder("moduleKey", "submodule/pom.xml").setContents("132").setCharset(StandardCharsets.UTF_8).setModuleBaseDir(path).build();
-        NPMDependencyReason npmReason = new NPMDependencyReason(packagLock);
+        NPMDependencyReason npmReason = new NPMDependencyReason(packageLock);
         MavenDependencyReason submodulepomReason = new MavenDependencyReason(subpom);
 
         // when

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/XMLReportParserHelperTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/XMLReportParserHelperTest.java
@@ -41,6 +41,7 @@ import org.sonar.dependencycheck.parser.element.Analysis;
 import org.sonar.dependencycheck.parser.element.Dependency;
 import org.sonar.dependencycheck.parser.element.Vulnerability;
 
+@Deprecated(since = "3.0.0", forRemoval = true)
 class XMLReportParserHelperTest extends ReportParserTest {
 
     @Override


### PR DESCRIPTION
XML-Reports are now deprecated, because I only want to support one report format.
With XML-Reports this plugin needs special [deserializers](https://github.com/dependency-check/dependency-check-sonar-plugin/tree/master/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/deserializer), that are quite complicated and difficult to maintain.

At the moment I can't find a way to update Jackson and don't have time to debug deeper into the problem.