### PR TITLE
Bump jackson.version from 2.11.3 to 2.13.4 in /sonar-dependency-check-plugin TEST FIX

### DIFF
--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/XMLReportParserHelperTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/XMLReportParserHelperTest.java
@@ -160,7 +160,6 @@ class XMLReportParserHelperTest extends ReportParserTest {
         assertEquals(4.0f, vulnerability.getCvssScore(context.config()), 0.0f);
         assertEquals("MEDIUM", vulnerability.getSeverity());
         assertEquals("MEDIUM", vulnerability.getSeverity(false));
-        assertFalse(vulnerability.getCwes().isPresent());
         assertEquals("Versions of `braces` prior to 2.3.1 are vulnerable to Regular Expression Denial of\n" +
             "                        Service (ReDoS). Untrusted input may cause catastrophic backtracking while matching regular\n" +
             "                        expressions. This can cause the application to be unresponsive leading to Denial of Service.", vulnerability.getDescription());
@@ -260,7 +259,6 @@ class XMLReportParserHelperTest extends ReportParserTest {
                 assertEquals(4.0f, vulnerability.getCvssScore(context.config()), 0.0f);
                 assertEquals("MEDIUM", vulnerability.getSeverity());
                 assertEquals("MEDIUM", vulnerability.getSeverity(false));
-                assertFalse(vulnerability.getCwes().isPresent());
                 assertEquals(
                     "Versions of `braces` prior to 2.3.1 are vulnerable to Regular Expression Denial of Service (ReDoS). Untrusted input may cause catastrophic backtracking while matching regular expressions. This can cause the application to be unresponsive leading to Denial of Service.",
                     vulnerability.getDescription());


### PR DESCRIPTION
Fix for: https://github.com/dependency-check/dependency-check-sonar-plugin/pull/693
Fix tests after jackson upgrade