### PR TITLE
Ability to select whether filename or filepath is used

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckConfiguration.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckConfiguration.java
@@ -111,6 +111,14 @@ public class DependencyCheckConfiguration {
                         .description("When enabled all SonarQube issues are flagged as Security-Hotspot.")
                         .defaultValue(Boolean.toString(DependencyCheckConstants.SECURITY_HOTSPOT_DEFAULT))
                         .type(PropertyType.BOOLEAN)
+                        .build(),
+                PropertyDefinition.builder(DependencyCheckConstants.USE_FILEPATH)
+                        .onQualifiers(Qualifiers.PROJECT)
+                        .subCategory(DependencyCheckConstants.SUB_CATEGORY_GENERAL)
+                        .name("Use Filepath")
+                        .description("When enabled Filepath is used instead of Filename.")
+                        .defaultValue(Boolean.toString(DependencyCheckConstants.USE_FILEPATH_DEFAULT))
+                        .type(PropertyType.BOOLEAN)
                         .build()
         );
     }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
@@ -41,6 +41,7 @@ public final class DependencyCheckConstants {
     public static final String SUMMARIZE_PROPERTY = "sonar.dependencyCheck.summarize";
     public static final String SKIP_PROPERTY = "sonar.dependencyCheck.skip";
     public static final String SECURITY_HOTSPOT = "sonar.dependencyCheck.securityHotspot";
+	public static final String USE_FILEPATH = "sonar.dependencyCheck.useFilePath";
 
     public static final Float SEVERITY_BLOCKER_DEFAULT = 9.0f;
     public static final Float SEVERITY_CRITICAL_DEFAULT = 7.0f;
@@ -57,6 +58,7 @@ public final class DependencyCheckConstants {
     public static final Boolean SUMMARIZE_PROPERTY_DEFAULT = Boolean.FALSE;
     public static final Boolean SKIP_PROPERTY_DEFAULT = Boolean.FALSE;
     public static final Boolean SECURITY_HOTSPOT_DEFAULT = Boolean.FALSE;
+	public static final Boolean USE_FILEPATH_DEFAULT = Boolean.FALSE;
 
     public static final String REPOSITORY_KEY = "OWASP";
     public static final String LANGUAGE_KEY = "neutral";

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
@@ -41,7 +41,7 @@ public final class DependencyCheckConstants {
     public static final String SUMMARIZE_PROPERTY = "sonar.dependencyCheck.summarize";
     public static final String SKIP_PROPERTY = "sonar.dependencyCheck.skip";
     public static final String SECURITY_HOTSPOT = "sonar.dependencyCheck.securityHotspot";
-	public static final String USE_FILEPATH = "sonar.dependencyCheck.useFilePath";
+    public static final String USE_FILEPATH = "sonar.dependencyCheck.useFilePath";
 
     public static final Float SEVERITY_BLOCKER_DEFAULT = 9.0f;
     public static final Float SEVERITY_CRITICAL_DEFAULT = 7.0f;
@@ -58,7 +58,7 @@ public final class DependencyCheckConstants {
     public static final Boolean SUMMARIZE_PROPERTY_DEFAULT = Boolean.FALSE;
     public static final Boolean SKIP_PROPERTY_DEFAULT = Boolean.FALSE;
     public static final Boolean SECURITY_HOTSPOT_DEFAULT = Boolean.FALSE;
-	public static final Boolean USE_FILEPATH_DEFAULT = Boolean.FALSE;
+    public static final Boolean USE_FILEPATH_DEFAULT = Boolean.FALSE;
 
     public static final String REPOSITORY_KEY = "OWASP";
     public static final String LANGUAGE_KEY = "neutral";

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
@@ -141,12 +141,12 @@ public final class DependencyCheckUtils {
      */
     public static String formatDescription(Dependency dependency, Vulnerability vulnerability, Configuration config) {
         StringBuilder sb = new StringBuilder();
-		if (config.getBoolean(DependencyCheckConstants.USE_FILEPATH)
-				.orElse(DependencyCheckConstants.USE_FILEPATH_DEFAULT)) {
-			sb.append("Filepath: ").append(dependency.getFilePath()).append(" | ");
-		} else {
-			sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
-		}
+        if (config.getBoolean(DependencyCheckConstants.USE_FILEPATH)
+                .orElse(DependencyCheckConstants.USE_FILEPATH_DEFAULT)) {
+            sb.append("Filepath: ").append(dependency.getFilePath()).append(" | ");
+        } else {
+            sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
+        }
         sb.append("Reference: ").append(vulnerability.getName()).append(" | ");
         sb.append("CVSS Score: ").append(vulnerability.getCvssScore(config)).append(" | ");
         Optional<String[]> vulnerabilityCwe = vulnerability.getCwes();
@@ -159,12 +159,12 @@ public final class DependencyCheckUtils {
 
     public static String formatDescription(Dependency dependency, Collection<Vulnerability> vulnerabilities, Vulnerability highestVulnerability, Configuration config) {
         StringBuilder sb = new StringBuilder();
-		if (config.getBoolean(DependencyCheckConstants.USE_FILEPATH)
-				.orElse(DependencyCheckConstants.USE_FILEPATH_DEFAULT)) {
-			sb.append("Filepath: ").append(dependency.getFilePath()).append(" | ");
-		} else {
-			sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
-		}
+        if (config.getBoolean(DependencyCheckConstants.USE_FILEPATH)
+                .orElse(DependencyCheckConstants.USE_FILEPATH_DEFAULT)) {
+            sb.append("Filepath: ").append(dependency.getFilePath()).append(" | ");
+        } else {
+            sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
+        }
         sb.append("Highest CVSS Score: ").append(highestVulnerability.getCvssScore(config)).append(" | ");
         sb.append("Amount of CVSS: ").append(vulnerabilities.size()).append(" | ");
         sb.append("References: ");

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
@@ -141,7 +141,12 @@ public final class DependencyCheckUtils {
      */
     public static String formatDescription(Dependency dependency, Vulnerability vulnerability, Configuration config) {
         StringBuilder sb = new StringBuilder();
-        sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
+		if (config.getBoolean(DependencyCheckConstants.USE_FILEPATH)
+				.orElse(DependencyCheckConstants.USE_FILEPATH_DEFAULT)) {
+			sb.append("Filepath: ").append(dependency.getFilePath()).append(" | ");
+		} else {
+			sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
+		}
         sb.append("Reference: ").append(vulnerability.getName()).append(" | ");
         sb.append("CVSS Score: ").append(vulnerability.getCvssScore(config)).append(" | ");
         Optional<String[]> vulnerabilityCwe = vulnerability.getCwes();
@@ -154,7 +159,12 @@ public final class DependencyCheckUtils {
 
     public static String formatDescription(Dependency dependency, Collection<Vulnerability> vulnerabilities, Vulnerability highestVulnerability, Configuration config) {
         StringBuilder sb = new StringBuilder();
-        sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
+		if (config.getBoolean(DependencyCheckConstants.USE_FILEPATH)
+				.orElse(DependencyCheckConstants.USE_FILEPATH_DEFAULT)) {
+			sb.append("Filepath: ").append(dependency.getFilePath()).append(" | ");
+		} else {
+			sb.append("Filename: ").append(dependency.getFileName()).append(" | ");
+		}
         sb.append("Highest CVSS Score: ").append(highestVulnerability.getCvssScore(config)).append(" | ");
         sb.append("Amount of CVSS: ").append(vulnerabilities.size()).append(" | ");
         sb.append("References: ");

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/DependencyCheckPluginTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/DependencyCheckPluginTest.java
@@ -39,6 +39,6 @@ class DependencyCheckPluginTest {
         Plugin.Context context = new PluginContextImpl.Builder().setSonarRuntime(runtime).build();
         DependencyCheckPlugin plugin = new DependencyCheckPlugin();
         plugin.define(context);
-        assertEquals(17, context.getExtensions().size());
+        assertEquals(18, context.getExtensions().size());
     }
 }


### PR DESCRIPTION
This is a small change to add a configuration switch for file path usage.
Background: I'm using the plugin to upload and comment owasp checks for multiple servers. It is tedious to search for the files on the server, if there is a new vulnerability. 
With this switch the Vulnerability Text contains the filepath from json instead of the filename.

Default behavior does not change