### PR TITLE
ignore 2 json fields to allow the plugin to work with dependency check 8.x

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Dependency.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Dependency.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-@JsonIgnoreProperties({"isVirtual", "sha256", "description", "projectReferences", "license", "relatedDependencies", "suppressedVulnerabilities", "suppressedVulnerabilityIds"})
+@JsonIgnoreProperties({"isVirtual", "sha256", "description", "projectReferences", "license", "relatedDependencies", "suppressedVulnerabilities", "suppressedVulnerabilityIds", "includedBy"})
 public class Dependency {
 
     private final String fileName;

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Vulnerability.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Vulnerability.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-@JsonIgnoreProperties({"notes", "references", "vulnerableSoftware", "unscored"})
+@JsonIgnoreProperties({"notes", "references", "vulnerableSoftware", "unscored", "knownExploitedVulnerability"})
 public class Vulnerability {
 
     private static final Logger LOGGER = Loggers.get(Vulnerability.class);


### PR DESCRIPTION
Fixes #748 as a work around by ignoring a couple of new fields. Tested with ~250 java projects.