### PR TITLE
Reinstate security hotspot rule definition

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinition.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinition.java
@@ -40,6 +40,8 @@ public class KnownCveRuleDefinition implements RulesDefinition {
 
         NewRule rule = repo.createRule(DependencyCheckConstants.RULE_KEY);
         fillOWASPRule(rule);
+        NewRule ruleWithSecurityHotspot = repo.createRule(DependencyCheckConstants.RULE_KEY_WITH_SECURITY_HOTSPOT);
+        fillOWASPRule(ruleWithSecurityHotspot);
         repo.done();
     }
 

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinition.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinition.java
@@ -21,9 +21,9 @@ package org.sonar.dependencycheck.rule;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.sonar.api.issue.impact.Severity;
 import org.sonar.api.issue.impact.SoftwareQuality;
 import org.sonar.api.rule.RuleStatus;
-import org.sonar.api.issue.impact.Severity;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.dependencycheck.base.DependencyCheckConstants;
 
@@ -40,8 +40,7 @@ public class KnownCveRuleDefinition implements RulesDefinition {
 
         NewRule rule = repo.createRule(DependencyCheckConstants.RULE_KEY);
         fillOWASPRule(rule);
-        NewRule ruleWithSecurityHotspot = repo.createRule(DependencyCheckConstants.RULE_KEY_WITH_SECURITY_HOTSPOT);
-        fillOWASPRule(ruleWithSecurityHotspot);
+        rule.addDeprecatedRuleKey(DependencyCheckConstants.REPOSITORY_KEY, DependencyCheckConstants.RULE_KEY_WITH_SECURITY_HOTSPOT);
         repo.done();
     }
 

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/rule/NeutralProfile.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/rule/NeutralProfile.java
@@ -28,8 +28,6 @@ public class NeutralProfile implements BuiltInQualityProfilesDefinition {
     public void define(Context context) {
         NewBuiltInQualityProfile dependencyCheckWay = context.createBuiltInQualityProfile("Neutral", DependencyCheckConstants.LANGUAGE_KEY);
         dependencyCheckWay.activateRule(DependencyCheckConstants.REPOSITORY_KEY, DependencyCheckConstants.RULE_KEY);
-        dependencyCheckWay.activateRule(DependencyCheckConstants.REPOSITORY_KEY,
-                DependencyCheckConstants.RULE_KEY_WITH_SECURITY_HOTSPOT);
         dependencyCheckWay.done();
     }
 }

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinitionTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinitionTest.java
@@ -54,7 +54,6 @@ class KnownCveRuleDefinitionTest {
 
         inOrder.verify(context).createRepository("OWASP","neutral");
         inOrder.verify(repo).createRule(DependencyCheckConstants.RULE_KEY);
-        inOrder.verify(repo).createRule(DependencyCheckConstants.RULE_KEY_WITH_SECURITY_HOTSPOT);
 
         inOrder.verify(repo).done();
         inOrder.verifyNoMoreInteractions();

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinitionTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/rule/KnownCveRuleDefinitionTest.java
@@ -38,7 +38,7 @@ class KnownCveRuleDefinitionTest {
     private KnownCveRuleDefinition rule = new KnownCveRuleDefinition();
 
     @Test
-    void define() throws Exception {
+    void define() {
         final RulesDefinition.Context context = mock(RulesDefinition.Context.class);
         final RulesDefinition.NewRepository repo = mock(RulesDefinition.NewRepository.class);
         final RulesDefinition.NewRule rule = mock(RulesDefinition.NewRule.class, RETURNS_SMART_NULLS);
@@ -54,6 +54,7 @@ class KnownCveRuleDefinitionTest {
 
         inOrder.verify(context).createRepository("OWASP","neutral");
         inOrder.verify(repo).createRule(DependencyCheckConstants.RULE_KEY);
+        inOrder.verify(repo).createRule(DependencyCheckConstants.RULE_KEY_WITH_SECURITY_HOTSPOT);
 
         inOrder.verify(repo).done();
         inOrder.verifyNoMoreInteractions();

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/rule/NeutralProfileTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/rule/NeutralProfileTest.java
@@ -20,7 +20,6 @@
 package org.sonar.dependencycheck.rule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
@@ -38,12 +37,11 @@ class NeutralProfileTest {
                 .profile(DependencyCheckConstants.LANGUAGE_KEY, "Neutral");
         assertEquals("neutral", profile.language());
         assertEquals("Neutral", profile.name());
-        assertEquals(2, profile.rules().size());
-        for (BuiltInActiveRule rule : profile.rules()) {
-            assertEquals(DependencyCheckConstants.REPOSITORY_KEY, rule.repoKey());
-            assertTrue(rule.ruleKey().equals(DependencyCheckConstants.RULE_KEY_WITH_SECURITY_HOTSPOT)
-                    || rule.ruleKey().equals(DependencyCheckConstants.RULE_KEY));
-        }
+        assertEquals(1, profile.rules().size());
+
+        BuiltInActiveRule rule = profile.rules().get(0);
+        assertEquals(DependencyCheckConstants.REPOSITORY_KEY, rule.repoKey());
+        assertEquals(DependencyCheckConstants.RULE_KEY, rule.ruleKey());
     }
 
 }


### PR DESCRIPTION
Related to https://github.com/dependency-check/dependency-check-sonar-plugin/issues/870
SonarQube 10.2 requires the security hotspot rule to be defined, otherwise it throws an error:

> Rule was removed: OWASP:UsingComponentWithKnownVulnerabilitySecurityHotspot