### PR TITLE
Add cvssv4 support in dependency-check json report.

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/CvssV4.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/CvssV4.java
@@ -1,0 +1,94 @@
+/*
+ * Dependency-Check Plugin for SonarQube
+ * Copyright (C) 2015-2024 dependency-check
+ * philipp.dallig@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.dependencycheck.parser.element;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@JsonIgnoreProperties({"attackComplexity",
+                        "attackRequirements",
+                        "attackVector",
+                        "automatable",
+                        "availabilityRequirements",
+                        "confidentialityRequirements",
+                        "environmentalScore",
+                        "environmentalSeverity",
+                        "exploitMaturity",
+                        "integrityRequirements",
+                        "modifiedAttackComplexity",
+                        "modifiedAttackRequirements",
+                        "modifiedAttackVector",
+                        "modifiedPrivilegesRequired",
+                        "modifiedSubsequentSystemAvailability",
+                        "modifiedSubsequentSystemConfidentiality",
+                        "modifiedSubsequentSystemIntegrity",
+                        "modifiedUserInteraction",
+                        "modifiedVulnerableSystemAvailability",
+                        "modifiedVulnerableSystemConfidentiality",
+                        "modifiedVulnerableSystemIntegrity",
+                        "privilegesRequired",
+                        "providerUrgency",
+                        "recovery",
+                        "safety",
+                        "source",
+                        "subsequentSystemAvailability",
+                        "subsequentSystemConfidentiality",
+                        "subsequentSystemIntegrity",
+                        "threatScore",
+                        "threatSeverity",
+                        "type",
+                        "userInteraction",
+                        "valueDensity",
+                        "vectorString",
+                        "version",
+                        "vulnerabilityResponseEffort",
+                        "vulnerableSystemAvailability",
+                        "vulnerableSystemConfidentiality",
+                        "vulnerableSystemIntegrity"})
+public class CvssV4 implements Cvss{
+    private final Float score;
+    private final String severity;
+
+    /**
+     * @param score
+     * @param severity
+     */
+    @JsonCreator
+    public CvssV4(@JsonProperty(value = "baseScore", required = true) @NonNull Float score,
+                  @JsonProperty(value = "baseSeverity", required = true) @NonNull String severity) {
+        this.score = score;
+        this.severity = severity;
+    }
+
+    @NonNull
+    @Override
+    public Float getScore() {
+        return score;
+    }
+    @NonNull
+    @Override
+    public String getSeverity() {
+        return severity;
+    }
+}

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Vulnerability.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Vulnerability.java
@@ -45,6 +45,7 @@ public class Vulnerability {
     private final String description;
     private final CvssV2 cvssv2;
     private final CvssV3 cvssv3;
+    private final CvssV4 cvssv4;
     private final String[] cwes;
 
     @JsonCreator
@@ -54,6 +55,7 @@ public class Vulnerability {
                          @JsonProperty(value = "cwes") @Nullable String[] cwe,
                          @JsonProperty(value = "cvssv2") @JacksonXmlProperty(localName="cvssV2") @Nullable CvssV2 cvssv2,
                          @JsonProperty(value = "cvssv3") @JacksonXmlProperty(localName="cvssV3") @Nullable CvssV3 cvssv3,
+                         @JsonProperty(value = "cvssv4") @JacksonXmlProperty(localName="cvssV4") @Nullable CvssV4 cvssv4,
                          @JsonProperty(value = "severity") @Nullable String severity) {
         this.name = name;
         this.source = source;
@@ -62,6 +64,7 @@ public class Vulnerability {
         this.cwes = cwe;
         this.cvssv2 = cvssv2;
         this.cvssv3 = cvssv3;
+        this.cvssv4 = cvssv4;
     }
 
     @NonNull
@@ -80,17 +83,28 @@ public class Vulnerability {
     }
 
     @NonNull
-    public Float getCvssScore(boolean preferCvssv3) {
-        Cvss cvss;
-        if (preferCvssv3) {
-            cvss = getCvssV3().orElse(getCvssV2().orElse(null));
-        } else {
-            cvss = getCvssV2().orElse(getCvssV3().orElse(null));
-        }
+    public Float getCvssScore(boolean preferMostRecentCvss) {
+        Cvss cvss = getPreferedCvss(preferMostRecentCvss);
         if (cvss != null) {
             return cvss.getScore();
         }
-        return DependencyCheckUtils.severityToCVSSScore(getSeverity(preferCvssv3));
+        return DependencyCheckUtils.severityToCVSSScore(getSeverity(preferMostRecentCvss));
+    }
+
+    /**
+     * Get the prefered Cvss entry.
+     * We may have several Cvss versions in the report. Let's get the prefered one.
+     * @param preferMostRecentCvss if {@code true}, get the most recent Cvss version availabe. if {@code false}, get the oldest one.
+     * @return the prefered Cvss entry.
+     */
+    private Cvss getPreferedCvss(boolean preferMostRecentCvss) {
+        Cvss cvss;
+        if (preferMostRecentCvss) {
+            cvss = getCvssV4().orElse(getCvssV3().orElse(getCvssV2().orElse(null)));
+        } else {
+            cvss = getCvssV2().orElse(getCvssV3().orElse(getCvssV4().orElse(null)));
+        }
+        return cvss;
     }
 
     @NonNull
@@ -99,7 +113,7 @@ public class Vulnerability {
     }
 
     @NonNull
-    public String getSeverity(boolean preferCvssv3) {
+    public String getSeverity(boolean preferMostRecentCvss) {
         /*
          * severity can be Unknown
          * https://github.com/jeremylong/DependencyCheck/commit/1dd037fa5ccfb3145817c9d5aec3263a5b2145c4
@@ -108,12 +122,7 @@ public class Vulnerability {
         if (severity != null && !unscoredSeverity) {
             return severity;
         }
-        Cvss cvss;
-        if (preferCvssv3) {
-            cvss = getCvssV3().orElse(getCvssV2().orElse(null));
-        } else {
-            cvss = getCvssV2().orElse(getCvssV3().orElse(null));
-        }
+        Cvss cvss = getPreferedCvss(preferMostRecentCvss);
         if (cvss != null) {
             return cvss.getSeverity();
         }
@@ -145,5 +154,10 @@ public class Vulnerability {
     public Optional<Cvss> getCvssV3() {
         return Optional.ofNullable(cvssv3);
     }
-
+    /**
+     * @return the cvssV4
+     */
+    public Optional<Cvss> getCvssV4() {
+        return Optional.ofNullable(cvssv4);
+    }
 }

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/base/DependencyCheckUtilsTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/base/DependencyCheckUtilsTest.java
@@ -245,7 +245,7 @@ class DependencyCheckUtilsTest {
         Collection<Identifier> packageidentifiers1 = new ArrayList<>();
         packageidentifiers1.add(identifier1);
         CvssV2 cvssV2 = new CvssV2(5.0f, "HIGH");
-        Vulnerability vulnerability1 = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null);
+        Vulnerability vulnerability1 = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null, null);
         List<Vulnerability> vulnerabilities1 = new ArrayList<>();
         vulnerabilities1.add(vulnerability1);
         Dependency dependency = new Dependency(null, null, null, null, Collections.emptyMap(), vulnerabilities1, packageidentifiers1, Collections.emptyList(), null);

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/JsonReportParserHelperTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/JsonReportParserHelperTest.java
@@ -72,4 +72,5 @@ class JsonReportParserHelperTest extends ReportParserTest {
         ReportParserException exception = assertThrows(ReportParserException.class, () -> JsonReportParserHelper.parse(inputStream), "No IOException thrown");
         assertEquals("IO Problem with JSON-Report", exception.getMessage());
     }
+
 }

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/ReportParserTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/ReportParserTest.java
@@ -181,4 +181,37 @@ abstract class ReportParserTest {
         dependency = iterator.next();
         assertEquals("xml-apis-1.0.b2.jar", dependency.getFileName());
     }
+
+    @Test
+    void parseReportWithCvssV4() throws Exception {
+        Analysis analysis = parseReport("reportWithCvssV4");
+
+        assertEquals("12.1.1", analysis.getScanInfo().getEngineVersion());
+        assertEquals("my-test-project", analysis.getProjectInfo().get().getName());
+        assertEquals("2025-05-01T00:00:00.000000000Z", analysis.getProjectInfo().get().getReportDate());
+
+        Collection<Dependency> dependencies = analysis.getDependencies();
+        assertEquals(1, dependencies.size());
+
+        Dependency dependency = dependencies.stream().findFirst().get();
+
+        assertNotNull(dependency.getVulnerabilities());
+        assertEquals(1, dependency.getVulnerabilities().size());
+        Vulnerability vulnerability = dependency.getVulnerabilities().get(0);
+
+        assertNotNull(vulnerability);
+
+        assertEquals("CVE-2024-9329", vulnerability.getName());
+        assertEquals("NVD", vulnerability.getSource());
+        assertEquals(6.9f, vulnerability.getCvssScore());
+        assertEquals("MEDIUM", vulnerability.getSeverity());
+
+        assertTrue(vulnerability.getCvssV2().isEmpty());
+        assertTrue(vulnerability.getCvssV3().isPresent());
+        assertTrue(vulnerability.getCvssV4().isPresent());
+        assertEquals(6.9f, vulnerability.getCvssV4().get().getScore());
+        assertEquals(6.1f, vulnerability.getCvssV3().get().getScore());
+        assertEquals("MEDIUM", vulnerability.getCvssV4().get().getSeverity());
+        assertEquals("MEDIUM", vulnerability.getCvssV3().get().getSeverity());
+    }
 }

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/element/VulnerabilityTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/element/VulnerabilityTest.java
@@ -31,62 +31,105 @@ class VulnerabilityTest {
     void testcvssScore() {
         CvssV2 cvssV2 = new CvssV2(5.0f, "HIGH");
         CvssV3 cvssV3 = new CvssV3(7.0f, "HIGHEST");
-        Vulnerability a = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, cvssV3, null);
+        CvssV4 cvssV4 = new CvssV4(9.0f, "VERYHIGHEST");
+        Vulnerability a = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, cvssV3, null, null);
         assertEquals(5.0f, a.getCvssScore(false));
         assertEquals(7.0f, a.getCvssScore());
         assertEquals(7.0f, a.getCvssScore(true));
 
-        Vulnerability b = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, null, null);
+        Vulnerability b = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, null, null, null);
         assertEquals(5.0f, b.getCvssScore(false));
         assertEquals(5.0f, b.getCvssScore());
         assertEquals(5.0f, b.getCvssScore(true));
 
-        Vulnerability c = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, cvssV3, null);
+        Vulnerability c = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, cvssV3, null, null);
         assertEquals(7.0f, c.getCvssScore(false));
         assertEquals(7.0f, c.getCvssScore());
         assertEquals(7.0f, c.getCvssScore(true));
 
-        Vulnerability d = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, null);
+        Vulnerability d = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, null, null);
         // It's 4.0f because we have no severity and default severity is MEDIUM
         assertEquals(4.0f, d.getCvssScore(false));
         assertEquals(4.0f, d.getCvssScore());
         assertEquals(4.0f, d.getCvssScore(true));
-
-        Vulnerability e = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, "Unknown");
+        
+        Vulnerability e = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, null, "Unknown");
         // It's 4.0f because we have severity is unknown and default severity is MEDIUM
         assertEquals(4.0f, e.getCvssScore(false));
         assertEquals(4.0f, e.getCvssScore());
         assertEquals(4.0f, e.getCvssScore(true));
-    }
+
+        Vulnerability f = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, cvssV4, null);
+        assertEquals(9.0f, f.getCvssScore(false));
+        assertEquals(9.0f, f.getCvssScore());
+        assertEquals(9.0f, f.getCvssScore(true));
+
+        Vulnerability g = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, cvssV3, cvssV4, null);
+        assertEquals(5.0f, g.getCvssScore(false));
+        assertEquals(9.0f, g.getCvssScore());
+        assertEquals(9.0f, g.getCvssScore(true));
+
+        Vulnerability h = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, null, cvssV4, null);
+        assertEquals(5.0f, h.getCvssScore(false));
+        assertEquals(9.0f, h.getCvssScore());
+        assertEquals(9.0f, h.getCvssScore(true));
+
+        Vulnerability i = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, cvssV3, cvssV4, null);
+        assertEquals(7.0f, i.getCvssScore(false));
+        assertEquals(9.0f, i.getCvssScore());
+        assertEquals(9.0f, i.getCvssScore(true));
+    }    
 
     @Test
     void testcvssSeverity() {
         CvssV2 cvssV2 = new CvssV2(5.0f, "HIGH");
         CvssV3 cvssV3 = new CvssV3(7.0f, "HIGHEST");
-        Vulnerability a = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, cvssV3, null);
+        CvssV4 cvssV4 = new CvssV4(9.0f, "VERYHIGHEST");
+
+        Vulnerability a = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, cvssV3, null, null);
         assertEquals("HIGH", a.getSeverity(false));
         assertEquals("HIGHEST", a.getSeverity());
         assertEquals("HIGHEST", a.getSeverity(true));
 
-        Vulnerability b = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, null, null);
+        Vulnerability b = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, null, null, null);
         assertEquals("HIGH", b.getSeverity(false));
         assertEquals("HIGH", b.getSeverity());
         assertEquals("HIGH", b.getSeverity(true));
 
-        Vulnerability c = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, cvssV3, null);
+        Vulnerability c = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, cvssV3, null, null);
         assertEquals("HIGHEST", c.getSeverity(false));
         assertEquals("HIGHEST", c.getSeverity());
         assertEquals("HIGHEST", c.getSeverity(true));
 
-        Vulnerability d = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, null);
+        Vulnerability d = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, null, null);
         assertEquals("MEDIUM", d.getSeverity(false));
         assertEquals("MEDIUM", d.getSeverity());
         assertEquals("MEDIUM", d.getSeverity(true));
 
-        Vulnerability e = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, "Unknown");
+        Vulnerability e = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, null, "Unknown");
         assertEquals("MEDIUM", e.getSeverity(false));
         assertEquals("MEDIUM", e.getSeverity());
         assertEquals("MEDIUM", e.getSeverity(true));
+
+        Vulnerability f = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, null, cvssV4, null);
+        assertEquals("VERYHIGHEST", f.getSeverity(false));
+        assertEquals("VERYHIGHEST", f.getSeverity());
+        assertEquals("VERYHIGHEST", f.getSeverity(true));
+
+        Vulnerability g = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, cvssV3, cvssV4, null);
+        assertEquals("HIGH", g.getSeverity(false));
+        assertEquals("VERYHIGHEST", g.getSeverity());
+        assertEquals("VERYHIGHEST", g.getSeverity(true));
+
+        Vulnerability h = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, cvssV2, null, cvssV4, null);
+        assertEquals("HIGH", h.getSeverity(false));
+        assertEquals("VERYHIGHEST", h.getSeverity());
+        assertEquals("VERYHIGHEST", h.getSeverity(true));
+
+        Vulnerability i = new Vulnerability("MyVulnerabilty", "NVD", "MyVulnerabiltyDescription", null, null, cvssV3, cvssV4, null);
+        assertEquals("HIGHEST", i.getSeverity(false));
+        assertEquals("VERYHIGHEST", i.getSeverity());
+        assertEquals("VERYHIGHEST", i.getSeverity(true));
     }
 }
 

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/reason/DependencyReasonSearcherTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/reason/DependencyReasonSearcherTest.java
@@ -97,7 +97,7 @@ class DependencyReasonSearcherTest {
         Collection<Identifier> packageidentifiers1 = new ArrayList<>();
         packageidentifiers1.add(identifier1);
         CvssV2 cvssV2 = new CvssV2(5.0f, "HIGH");
-        Vulnerability vulnerability1 = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null);
+        Vulnerability vulnerability1 = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null, null);
         List<Vulnerability> vulnerabilities1 = new ArrayList<>();
         vulnerabilities1.add(vulnerability1);
         Dependency dependency1 = new Dependency(null, null, null, null, Collections.emptyMap(), vulnerabilities1, packageidentifiers1, Collections.emptyList(), null);
@@ -105,7 +105,7 @@ class DependencyReasonSearcherTest {
         Identifier identifier2 = new Identifier("pkg:maven/org.springframework/spring@2.0.8", Confidence.HIGHEST);
         Collection<Identifier> packageidentifiers2 = new ArrayList<>();
         packageidentifiers2.add(identifier2);
-        Vulnerability vulnerability2 = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null);
+        Vulnerability vulnerability2 = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null, null);
         List<Vulnerability> vulnerabilities2 = new ArrayList<>();
         vulnerabilities2.add(vulnerability2);
         Dependency dependency2 = new Dependency(null, null, null, null, Collections.emptyMap(), vulnerabilities1, packageidentifiers2, Collections.emptyList(), null);
@@ -153,7 +153,7 @@ class DependencyReasonSearcherTest {
         Collection<Identifier> packageidentifiers = new ArrayList<>();
         packageidentifiers.add(identifier);
         CvssV2 cvssV2 = new CvssV2(5.0f, "HIGH");
-        Vulnerability vulnerability = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null);
+        Vulnerability vulnerability = new Vulnerability("Test name", "NVD", "MyDescription", null, cvssV2, null, null, null);
         List<Vulnerability> vulnerabilities = new ArrayList<>();
         vulnerabilities.add(vulnerability);
         Dependency dependency = new Dependency(null, null, null, null, Collections.emptyMap(),vulnerabilities, packageidentifiers, Collections.emptyList(), null);

--- a/sonar-dependency-check-plugin/src/test/resources/reportWithCvssV4/dependency-check-report.json
+++ b/sonar-dependency-check-plugin/src/test/resources/reportWithCvssV4/dependency-check-report.json
@@ -1,0 +1,286 @@
+{
+  "reportSchema": "1.1",
+  "scanInfo": {
+    "engineVersion": "12.1.1",
+    "dataSource": [
+      {
+        "name": "NVD API Last Checked",
+        "timestamp": "2025-01-01T00:00:00Z"
+      },
+      {
+        "name": "NVD API Last Modified",
+        "timestamp": "2025-01-01T00:00:00Z"
+      },
+      {
+        "name": "NVD Cache Last Checked",
+        "timestamp": "2025-01-01T00:00:00Z"
+      },
+      {
+        "name": "NVD Cache Last Modified",
+        "timestamp": "2025-01-01T00:00:00Z"
+      }
+    ]
+  },
+  "projectInfo": {
+    "name": "my-test-project",
+    "reportDate": "2025-05-01T00:00:00.000000000Z",
+    "credits": {
+      "NVD": "This product uses the NVD API but is not endorsed or certified by the NVD. This report contains data retrieved from the National Vulnerability Database: https://nvd.nist.gov",
+      "CISA": "This report may contain data retrieved from the CISA Known Exploited Vulnerability Catalog: https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "NPM": "This report may contain data retrieved from the Github Advisory Database (via NPM Audit API): https://github.com/advisories/",
+      "RETIREJS": "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX": "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies": [
+    {
+      "isVirtual": false,
+      "fileName": "org.glassfish.hk2.osgi-resource-locator-1.0.3.jar",
+      "filePath": "/work/target/quarkus-app/lib/main/org.glassfish.hk2.osgi-resource-locator-1.0.3.jar",
+      "md5": "e7e82b82118c5387ae45f7bf3892909b",
+      "sha1": "de3b21279df7e755e38275137539be5e2c80dd58",
+      "sha256": "aab5d7849f7cfcda2cc7c541ba1bd365151d42276f151c825387245dfde3dd74",
+      "description": "Used by various API providers that rely on META-INF/services mechanism to locate providers.",
+      "license": "http://www.eclipse.org/legal/epl-2.0, https://www.gnu.org/software/classpath/license.html",
+      "evidenceCollected": {
+        "vendorEvidence": [
+          {
+            "type": "vendor",
+            "confidence": "HIGH",
+            "source": "file",
+            "name": "name",
+            "value": "org.glassfish.hk2.osgi-resource-locator"
+          },
+          {
+            "type": "vendor",
+            "confidence": "HIGHEST",
+            "source": "jar",
+            "name": "package name",
+            "value": "glassfish"
+          },
+          {
+            "type": "vendor",
+            "confidence": "LOW",
+            "source": "jar",
+            "name": "package name",
+            "value": "glassfish"
+          },
+          {
+            "type": "vendor",
+            "confidence": "HIGHEST",
+            "source": "jar",
+            "name": "package name",
+            "value": "hk2"
+          },
+          {
+            "type": "vendor",
+            "confidence": "LOW",
+            "source": "jar",
+            "name": "package name",
+            "value": "hk2"
+          },
+          {
+            "type": "vendor",
+            "confidence": "LOW",
+            "source": "jar",
+            "name": "package name",
+            "value": "osgiresourcelocator"
+          },
+          {
+            "type": "vendor",
+            "confidence": "LOW",
+            "source": "Manifest",
+            "name": "bundle-activationpolicy",
+            "value": "lazy"
+          },
+          {
+            "type": "vendor",
+            "confidence": "LOW",
+            "source": "Manifest",
+            "name": "bundle-docurl",
+            "value": "https://www.eclipse.org"
+          },
+          {
+            "type": "vendor",
+            "confidence": "MEDIUM",
+            "source": "Manifest",
+            "name": "bundle-symbolicname",
+            "value": "org.glassfish.hk2.osgi-resource-locator"
+          }
+        ],
+        "productEvidence": [
+          {
+            "type": "product",
+            "confidence": "HIGH",
+            "source": "file",
+            "name": "name",
+            "value": "org.glassfish.hk2.osgi-resource-locator"
+          },
+          {
+            "type": "product",
+            "confidence": "HIGHEST",
+            "source": "jar",
+            "name": "package name",
+            "value": "glassfish"
+          },
+          {
+            "type": "product",
+            "confidence": "HIGHEST",
+            "source": "jar",
+            "name": "package name",
+            "value": "hk2"
+          },
+          {
+            "type": "product",
+            "confidence": "LOW",
+            "source": "jar",
+            "name": "package name",
+            "value": "hk2"
+          },
+          {
+            "type": "product",
+            "confidence": "LOW",
+            "source": "jar",
+            "name": "package name",
+            "value": "osgiresourcelocator"
+          },
+          {
+            "type": "product",
+            "confidence": "LOW",
+            "source": "Manifest",
+            "name": "bundle-activationpolicy",
+            "value": "lazy"
+          },
+          {
+            "type": "product",
+            "confidence": "LOW",
+            "source": "Manifest",
+            "name": "bundle-docurl",
+            "value": "https://www.eclipse.org"
+          },
+          {
+            "type": "product",
+            "confidence": "MEDIUM",
+            "source": "Manifest",
+            "name": "Bundle-Name",
+            "value": "OSGi resource locator"
+          },
+          {
+            "type": "product",
+            "confidence": "MEDIUM",
+            "source": "Manifest",
+            "name": "bundle-symbolicname",
+            "value": "org.glassfish.hk2.osgi-resource-locator"
+          }
+        ],
+        "versionEvidence": [
+          {
+            "type": "version",
+            "confidence": "MEDIUM",
+            "source": "file",
+            "name": "name",
+            "value": "org.glassfish.hk2.osgi-resource-locator"
+          },
+          {
+            "type": "version",
+            "confidence": "HIGH",
+            "source": "file",
+            "name": "version",
+            "value": "1.0.3"
+          },
+          {
+            "type": "version",
+            "confidence": "HIGH",
+            "source": "Manifest",
+            "name": "Bundle-Version",
+            "value": "1.0.3"
+          }
+        ]
+      },
+      "vulnerabilityIds": [
+        {
+          "id": "cpe:2.3:a:eclipse:glassfish:1.0.3:*:*:*:*:*:*:*",
+          "confidence": "LOW"
+        }
+      ],
+      "vulnerabilities": [
+        {
+          "source": "NVD",
+          "name": "CVE-2024-9329",
+          "severity": "MEDIUM",
+          "cvssv3": {
+            "baseScore": 6.1,
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "REQUIRED",
+            "scope": "CHANGED",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "availabilityImpact": "NONE",
+            "baseSeverity": "MEDIUM",
+            "exploitabilityScore": "2.8",
+            "impactScore": "2.7",
+            "version": "3.1"
+          },
+          "cvssv4": {
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:N/V:X/RE:X/U:X",
+            "source": "emo@eclipse.org",
+            "type": "Secondary",
+            "version": "4.0",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "attackRequirements": "NONE",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "exploitMaturity": "NOT_DEFINED",
+            "modifiedAttackVector": "NOT_DEFINED",
+            "modifiedAttackComplexity": "NOT_DEFINED",
+            "modifiedAttackRequirements": "NOT_DEFINED",
+            "modifiedPrivilegesRequired": "NOT_DEFINED",
+            "modifiedUserInteraction": "NOT_DEFINED",
+            "safety": "NOT_DEFINED",
+            "automatable": "NOT_DEFINED",
+            "recovery": "NOT_DEFINED",
+            "valueDensity": "NOT_DEFINED",
+            "vulnerabilityResponseEffort": "NOT_DEFINED",
+            "providerUrgency": "NOT_DEFINED",
+            "baseScore": 6.9,
+            "baseSeverity": "MEDIUM"
+          },
+          "cwes": [
+            "CWE-601",
+            "CWE-233"
+          ],
+          "description": "In Eclipse Glassfish versions before 7.0.17, The Host HTTP parameter could cause the web application to redirect to the specified URL, when the requested endpoint is '/management/domain'. By modifying the URL value to a malicious site, an attacker may successfully launch a phishing scam and steal user credentials.",
+          "notes": "",
+          "references": [
+            {
+              "source": "emo@eclipse.org",
+              "url": "https://github.com/eclipse-ee4j/glassfish/pull/25106",
+              "name": "EXPLOIT,PATCH"
+            },
+            {
+              "source": "emo@eclipse.org",
+              "url": "https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/232",
+              "name": "EXPLOIT,VENDOR_ADVISORY"
+            },
+            {
+              "source": "af854a3a-2127-422b-91ae-364da2661108",
+              "url": "https://www.gruppotim.it/it/footer/red-team.html"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:eclipse:glassfish:*:*:*:*:*:*:*:*",
+                "vulnerabilityIdMatched": "true",
+                "versionEndExcluding": "7.0.17"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
DependencyCheck can generate CVSSv4 information.

This PR aims to add support for this, while keeping consistency with CVSSv3/CVSSv2 handling.

Should close #1038 .